### PR TITLE
Update get-started.mdx to avoid crashing when app launching on iOS 12 

### DIFF
--- a/docs/docs/get-started.mdx
+++ b/docs/docs/get-started.mdx
@@ -35,6 +35,9 @@ npm install react-native-iap
 cd ios; pod install; cd -
 ```
 
+> Note: For iOS 12.x, set project in Xcode as below:   
+> Build Phases -> Link Binary With Libraries -> +(Add) -> SwiftUI.framework, Optional
+
 You can now get started hacking!
 
 ### `Android`


### PR DESCRIPTION
## Summary:

After the ipa package generated by Xcode archive  was installed on on iPhone 6 / iOS 12. It crashed every time I opened the app.

More information can be found here [#2701](https://github.com/dooboolab-community/react-native-iap/issues/2701)


## What was done:

Add a note in get-started.mdx. So developers know to do extra configuration on iOS 12 to avoid crashes
